### PR TITLE
Implement object/array based hook assignment

### DIFF
--- a/lib/mongorito.js
+++ b/lib/mongorito.js
@@ -152,34 +152,37 @@ var InstanceMethods = {
 	configure: function () {
 	  
 	},
-	hook: function(when, action, method, prepend){
-		var array_method = prepend ? 'unshift' : 'push';
+	hook: function (when, action, method) {
 
-		if('object' === typeof when){
+		if ('object' === typeof when) {
+			var keys = Object.keys(when);
 
-			for(var key in when){
-				this.hook(key, when[key])
-			}
-			return;
-		}
+			keys.forEach((function(key){
+				var split = key.split(':');
+				var meth = when[key];
 
-		if(action instanceof Array){
-			action.forEach((function(hash){
-				this.hook(when, hash.action, hash.method)
+				this.hook(split[0], split[1], meth);
+							
 			}).bind(this));
+
 			return;
 		}
 
-		if(method instanceof Array){
-			method.forEach((function(method_name){
-				this.hook(when, action, method_name)
+		if (method instanceof Array) {
+			method.forEach((function(methodName){
+				this.hook(when, action, methodName)
 			}).bind(this))
 			return;
 		}
+		
+		if ('around' === when) {
+			method = this[method];
+			this.hooks.before[action].push(method);
+			this.hooks.after[action].unshift(method);
+		} else {		
+			this.hooks[when][action].push(this[method]);
+		}
 
-		if(when === 'around') return this.around(action, method);
-
-        this.hooks[when][action][array_method](this[method]);
 	},
 	before: function (action, method) {
 		this.hook('before', action, method);
@@ -190,14 +193,11 @@ var InstanceMethods = {
 	},
 	
 	around: function (action, method) {
-		if('object' === typeof action) action
-		this.hook('before', action, method);
-		this.hook('after', action, method, true);
+		this.hook('around', action, method);
 	},
 	runHooks: function *(when, action) {
 		yield compose(this.hooks[when][action]).call(this);
 	},
-	
 	save: function *() {
 	  // set default values if needed
 	  this.setDefaults();

--- a/test/mongorito.test.js
+++ b/test/mongorito.test.js
@@ -638,19 +638,13 @@ describe ('Mongorito', function () {
 						collection: 'posts',
 						configure: function(){
 							this.hook({
-						  	before: [
-						  		{action: 'save', method: 'beforeSave'},
-						  		{action: 'create', method: ['firstBeforeCreate', 'secondBeforeCreate']}
-						  		],
-						  	after: [
-						  		{action: 'save', method: 'afterSave'},
-						  		{action: 'create', method: 'firstAfterCreate'}
-						  	],
-						  	around: [
-						  		{action: 'create', method: ['firstAroundCreate', 'secondAroundCreate']}
-						  	]
-						  	});
-
+								'before:save':'beforeSave',
+								'before:create': ['firstBeforeCreate', 'secondBeforeCreate'],
+								'after:save':'afterSave',
+								'after:create': 'firstAfterCreate',
+								'around:create': ['firstAroundCreate', 'secondAroundCreate']
+							});
+							
 						  	this.after('create', ['secondAfterCreate', 'thirdAfterCreate']);
 						},
 						beforeSave: function *(next){


### PR DESCRIPTION
Add the #.hook method to instances of model, which provides an API for assign any kind of hook, and allows one to assign hooks using a configuration hash, or using a hook name and an array of methods. Makes all hook methods delegate to #.hook. Add tests for functionality.
