### PR TITLE
Populate fails if key doesn't exist

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -399,7 +399,10 @@ Query.prototype.find = function (query, options) {
 		.map(function (doc) {
 			return Promise.each(populate, function (key) {
 				let childModel = options.populate[key];
-				let idsArray = doc[key];
+
+				// in case we have a collection with a mix of documents 
+				// that may or may not have the key fallback to an empty array
+				let idsArray = doc[key] || [];
 
 				let promise = childModel.findById(idsArray);
 


### PR DESCRIPTION
I noticed one bug in v2.2.0, if you try to populate across a collection of documents on a key that may or may not exist Mongorito throws an exception. The variable idsArray ends up being undefined and then any calls on it fail. 

I figured a simple fix would be to fallback to an empty array but let me know if you think a better solution fits.