### PR TITLE
Fix flattern-obj omits empty object field

### DIFF
--- a/test/fields.js
+++ b/test/fields.js
@@ -41,6 +41,21 @@ test('unset fields', async t => {
 	t.falsy(post.get('awesome'));
 });
 
+test('empty object fields', async t => {
+	const data = {awesome: true, empty: {}, embed: {good: true}};
+	const post = new Post(data);
+	await post.save();
+
+	t.true(post.get('awesome'));
+	t.deepEqual(post.get('empty'), {});
+	t.true(post.get('embed.good'));
+
+	post.unset('empty');
+	await post.save();
+
+	t.is(post.get('empty'), undefined);
+});
+
 test('increment fields', async t => {
 	const post = new Post({views: 1, total: 0});
 	await post.save();

--- a/util/flatten-obj.js
+++ b/util/flatten-obj.js
@@ -14,10 +14,14 @@ function flattenObject(obj) {
 
 		if (isObject(value)) {
 			value = flattenObject(value);
-
-			Object.keys(value).forEach(childKey => {
-				newObj[childKey] = value[childKey];
-			});
+			const keys = Object.keys(value);
+			if (keys.length === 0) {
+				newObj[key] = value;
+			} else {
+				keys.forEach(childKey => {
+					newObj[childKey] = value[childKey];
+				});
+			}
 		} else {
 			newObj[key] = value;
 		}


### PR DESCRIPTION
```js

const post = new Posts({
   field1: '...',
   someFields: {}
})

await post()

post.get() // { field: '...' }, someFields is missing
```

An empty object field (like `someFields` in `post`) won't be saved, this PR should fix it.