### PR TITLE
ensureIndex fix

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -245,7 +245,7 @@ const classMethods = {
 		const args = [].slice.call(arguments);
 
 		return this.dbCollection()
-			.then(collection => collection.ensureIndex.apply(collection, args));
+			.then(collection => collection.createIndex.apply(collection, args));
 	},
 
 	dropIndex() {


### PR DESCRIPTION
latest version of mongodb native fails ``save()`` and ``catch()`` if ``createIndex`` is not used