### PR TITLE
Support array sort fields

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -104,7 +104,13 @@ class Query {
 		}
 
 		if (Array.isArray(field)) {
-			field.forEach(field => this.sort(field));
+			// The array syntax `.sort([['field', 1], ['test', -1]])` can only be used with [mongodb driver >= 2.0.46](https://github.com/mongodb/node-mongodb-native/blob/2.1/HISTORY.md#2046-2015-10-15).
+
+			if (field.length > 0 && Array.isArray(field[0])) {
+				this.mquery.sort(field);
+			} else {
+				field.forEach(field => this.sort(field));
+			}
 			return this;
 		}
 

--- a/test/queries.js
+++ b/test/queries.js
@@ -291,6 +291,16 @@ test('sort documents', async t => {
 		const post = posts[n];
 		t.is(post.get('index'), 3 - n);
 	}
+
+	posts = await Post.sort([['_id', -1]]).find();
+	t.is(posts.length, 4);
+
+	n = 4;
+
+	while (n--) {
+		const post = posts[n];
+		t.is(post.get('index'), n);
+	}
 });
 
 test('find documents and include only one selected field', async t => {


### PR DESCRIPTION
The order of hashmap is not reliable( actually only numeric  keys ), and this problem has been fixed in node-mongodb-native and mquery.

https://github.com/aheckmann/mquery/blob/master/lib/mquery.js#L1214
https://github.com/mongodb/node-mongodb-native/blob/2.1/HISTORY.md#2046-2015-10-15


