### PR TITLE
Amend issues with findById using string

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const isObject = require('is-plain-obj');
+const {ObjectID} = require('mongodb');
 const queryMethods = require('./query-methods');
 
 class Query {
@@ -42,7 +43,7 @@ class Query {
 			throw new TypeError(`Expected \`id\` to be object or string, got ${typeof id}`);
 		}
 
-		this.where('_id', id);
+		this.where('_id', (typeof id === 'string' ? ObjectID(id) : id));
 
 		return this.Model.query('findOne', this.query)
 			.then(doc => doc ? new this.Model(doc) : null);


### PR DESCRIPTION
`findById` doesn't pass mongoDB `ObjectID` and therefore will always return `null` when searching by string.