### PR TITLE
Chore/update mongodb package

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -30,12 +30,13 @@ class Database {
 
 		this.state = STATE_CONNECTING;
 
-		this._connectionPromise = MongoClient.connect(this.urls.join(','), this.options)
-			.then(db => {
+		this._connectionPromise = new MongoClient(this.urls.join(','), this.options)
+			.connect()
+			.then(client => {
 				this.state = STATE_CONNECTED;
-				this._connection = db;
+				this._connection = client;
 
-				return db;
+				return client;
 			});
 
 		return this._connectionPromise;
@@ -57,8 +58,8 @@ class Database {
 
 	disconnect() {
 		return this.connection()
-			.then(db => {
-				db.close();
+			.then(client => {
+				client.close();
 				this.state = STATE_DISCONNECTED;
 			});
 	}

--- a/lib/model.js
+++ b/lib/model.js
@@ -131,8 +131,9 @@ Model.getConnection = function () {
 
 Model.getCollection = function () {
 	return this.getConnection()
-		.then(db => {
+		.then(client => {
 			const name = result(this.prototype, 'collection');
+			const db = client.db(client.s.options.dbName);
 
 			return db.collection(name);
 		});

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lodash.omit": "^4.5.0",
     "lodash.result": "^4.5.2",
     "map-obj": "^2.0.0",
-    "mongodb": "^2.2.9",
+    "mongodb": "^3.0.2",
     "mquery": "^1.11.0",
     "pluralize": "^3.0.0",
     "redux": "^3.6.0"

--- a/test/models.js
+++ b/test/models.js
@@ -225,7 +225,8 @@ test('automatically set collection name', async t => {
 });
 
 test('override collection name', async t => {
-	const {db} = t.context;
+	const {db, db: {_connection: mongoClient}} = t.context;
+	const dbConnection = mongoClient.db(mongoClient.s.options.dbName);
 
 	class CustomPost extends mongorito.Model {
 		collection() {
@@ -238,7 +239,7 @@ test('override collection name', async t => {
 	const post = new CustomPost({title: 'Greatness'});
 	await post.save();
 
-	const allCollections = await db._connection.collections();
+	const allCollections = await dbConnection.collections();
 	const collections = allCollections
 		.map(c => c.collectionName)
 		.filter(name => !name.includes('system'))


### PR DESCRIPTION
Updates the `mongodb` npm package to it's latest version.

Some small changes were made to Mongorito's code. Specifically:
- `MongoClient.connect()` was deprecated, now using `new MongoClient().connect()`
- `MongoClient.collections` no longer exists. You have to create a db instance with `MongoClient.db()` on which the `collections()` function now exists.

While none of the Mongorito APIs or methods have changes, the update to _mongobd@3_ package may result in breaking changes if someone used Mongorito and made use of private/undocuments Mongorito properties (e.g. mongorito's database._connection property). Therefore might make sense to release this (in conjunction with #205) as a major version release, just in case.