### PR TITLE
feat: add support for findOneAndUpdate query method

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -203,6 +203,7 @@ Model.embeds = function (key, model) {
 const methods = [
 	'find',
 	'findOne',
+	'findOneAndUpdate',
 	'findById',
 	'count',
 	'sort',

--- a/lib/query-methods.js
+++ b/lib/query-methods.js
@@ -8,6 +8,7 @@ const ignore = [
 	'setOptions',
 	'collection',
 	'findOne',
+	'findOneAndUpdate',
 	'remove',
 	'count',
 	'thunk',

--- a/lib/query.js
+++ b/lib/query.js
@@ -33,6 +33,25 @@ class Query {
 			.then(doc => doc ? new this.Model(doc) : null);
 	}
 
+	findOneAndUpdate(query = {}, updateDocument = {}, options = {new: true}) {
+		if (typeof query !== 'undefined' && typeof query !== 'object') {
+			throw new TypeError(`Expected \`query\` to be object or undefined, got ${typeof query}`);
+		}
+
+		if (typeof updateDocument !== 'object') {
+			throw new TypeError(`Expected \`updateDocument\` to be object, got ${typeof updateDocument}`);
+		}
+
+		if (typeof options !== 'undefined' && typeof options !== 'object') {
+			throw new TypeError(`Expected \`options\` to be object or undefined, got ${typeof options}`);
+		}
+
+		this.query.push(['findOneAndUpdate', [query, updateDocument, options]]);
+
+		return this.Model.query('findOneAndUpdate', this.query)
+			.then(doc => doc && doc.value ? new this.Model(doc.value) : null);
+	}
+
 	findById(id) {
 		if (typeof id !== 'object' && typeof id !== 'string') {
 			throw new TypeError(`Expected \`id\` to be object or string, got ${typeof id}`);

--- a/test/queries.js
+++ b/test/queries.js
@@ -62,6 +62,52 @@ test('find one document - missing', async t => {
 	t.is(post, null);
 });
 
+test('findOneAndUpadate should throw error when given invalid parameters', async t => {
+	t.throws(() => Post.findOneAndUpdate(1));
+	t.throws(() => Post.findOneAndUpdate({}, 1));
+	t.throws(() => Post.findOneAndUpdate({}, {}, 1));
+});
+
+test('find one document and update using findOneAndUpdate', async t => {
+	const createdPost = new Post();
+	await createdPost.save();
+
+	const posts = await Post.count();
+	t.is(posts, 1);
+
+	const post = await Post.findOneAndUpdate(
+		{_id: createdPost.get('_id')},
+		{foo: 'bar'}
+	);
+
+	t.is(getId(post), getId(createdPost));
+	t.deepEqual(post.get(), {
+		_id: createdPost.get('_id'),
+		foo: 'bar'
+	});
+});
+
+test('find one document - missing, don\'t upsert using findOneAndUpdate', async t => {
+	const post = await Post.findOneAndUpdate({awesome: false});
+	t.is(post, null);
+
+	const posts = await Post.count();
+	t.is(posts, 0);
+});
+
+test('find one document - missing, and upsert using findOneAndUpdate', async t => {
+	const post = await Post.findOneAndUpdate(
+		{awesome: false},
+		{foo: 'bar'},
+		{upsert: true}
+	);
+
+	t.is(post.get('foo'), 'bar');
+
+	const posts = await Post.count();
+	t.is(posts, 1);
+});
+
 test('find one document by id', async t => {
 	const data = postFixture();
 	const createdPost = new Post(data);


### PR DESCRIPTION
Adds support for `Model.findOneAndUpdate(query, updateDocument, options)`

Closes #203 

After this one's merged, I'll PR `findOneAndRemove()` as well.

/cc @vadimdemedes 😄 